### PR TITLE
remove indirection for arguments and expose validation with tests

### DIFF
--- a/image-inspector_test.go
+++ b/image-inspector_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	noURI := NewDefaultImageInspectorOptions()
+	noURI.URI = ""
+
+	dockerCfgAndUsername := NewDefaultImageInspectorOptions()
+	dockerCfgAndUsername.DockerCfg = "foo"
+	dockerCfgAndUsername.Username = "bar"
+
+	usernameNoPasswordFile := NewDefaultImageInspectorOptions()
+	usernameNoPasswordFile.Username = "foo"
+
+	noServeAndChroot := NewDefaultImageInspectorOptions()
+	noServeAndChroot.Chroot = true
+
+	goodConfigUsername := NewDefaultImageInspectorOptions()
+	goodConfigUsername.URI = "uri"
+	goodConfigUsername.Image = "image"
+	goodConfigUsername.Username = "username"
+	goodConfigUsername.PasswordFile = "password"
+
+	goodConfigWithDockerCfg := NewDefaultImageInspectorOptions()
+	goodConfigWithDockerCfg.URI = "uri"
+	goodConfigWithDockerCfg.Image = "image"
+	goodConfigWithDockerCfg.DockerCfg = "docker"
+
+	tests := map[string]struct {
+		inspector      *ImageInspectorOptions
+		shouldValidate bool
+	}{
+		"no uri":                        {inspector: noURI, shouldValidate: false},
+		"no image":                      {inspector: NewDefaultImageInspectorOptions(), shouldValidate: false},
+		"docker config and username":    {inspector: dockerCfgAndUsername, shouldValidate: false},
+		"username and no password file": {inspector: usernameNoPasswordFile, shouldValidate: false},
+		"no serve and chroot":           {inspector: noServeAndChroot, shouldValidate: false},
+		"good config with username":     {inspector: goodConfigUsername, shouldValidate: true},
+		"good config with docker cfg":   {inspector: goodConfigWithDockerCfg, shouldValidate: true},
+	}
+
+	for k, v := range tests {
+		err := v.inspector.Validate()
+
+		if v.shouldValidate && err != nil {
+			t.Errorf("%s expected to validate but received %v", k, err)
+		}
+		if !v.shouldValidate && err == nil {
+			t.Errorf("%s expected to be invalid but received no error", k)
+		}
+	}
+}


### PR DESCRIPTION
minor refactor to remove the variable indirection on the command options and moved validation to it's own method so it can be tested.

~~(still need to do a manual test of the executable to ensure I didn't miss anything, have only ensured compilation and tests run so far).~~  manual test looked ok:

```
[pweil@localhost image-inspector]$ ./image-inspector --image=docker.io/fedora:latest --path=/tmp/image-content --serve=0.0.0.0:8080
2016/04/05 14:39:36 Pulling image docker.io/fedora:latest
2016/04/05 14:40:08 Extracting image docker.io/fedora:latest to /tmp/image-content
2016/04/05 14:40:10 !!!WARNING!!! It is insecure to serve the image content without changing
2016/04/05 14:40:10 root (--chroot). Absolute-path symlinks in the image can lead to disclose
2016/04/05 14:40:10 information of the hosting system.
2016/04/05 14:40:10 Serving image content /tmp/image-content on webdav://0.0.0.0:8080/api/v1/content/
```

@simon3z 
