### PR TITLE
factor out image serving

### DIFF
--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -1,0 +1,37 @@
+package imageserver
+
+import (
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+// ImageServer abstracts the serving of image information.
+type ImageServer interface {
+	// ServeImage Serves the image
+	ServeImage(imageMetadata *docker.Image) error
+}
+
+// APIVersions holds a slice of supported API versions.
+type APIVersions struct {
+	// Versions is the supported API versions
+	Versions []string `json:"versions"`
+}
+
+// ImageServerOptions is used to configure an image server.
+type ImageServerOptions struct {
+	// ServePath is the root path/port of serving. ex 0.0.0.0:8080
+	ServePath string
+	// HealthzURL is the relative url of the health check. ex /healthz
+	HealthzURL string
+	// APIURL is the relative url where the api will be served.  ex /api
+	APIURL string
+	// APIVersions are the supported API versions.
+	APIVersions APIVersions
+	// MetadataURL is the relative url of the metadata content.  ex /api/v1/metadata
+	MetadataURL string
+	// ContentURL is the relative url of the content.  ex /api/v1/content/
+	ContentURL string
+	// ImageServeURL is the location that the image is being served from.
+	// NOTE: if the image server supports a chroot the server implementation will perform
+	// the chroot based on this URL.
+	ImageServeURL string
+}

--- a/pkg/imageserver/webdav.go
+++ b/pkg/imageserver/webdav.go
@@ -1,0 +1,83 @@
+package imageserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"syscall"
+
+	"golang.org/x/net/webdav"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+const (
+	// CHROOT_SERVE_PATH is the path to server if we are performing a chroot
+	// this probably does not belong here.
+	CHROOT_SERVE_PATH = "/"
+)
+
+// webdavImageServer implements ImageServer.
+type webdavImageServer struct {
+	opts   ImageServerOptions
+	chroot bool
+}
+
+// ensures this always implements the interface or fail compilation.
+var _ ImageServer = &webdavImageServer{}
+
+// NewWebdavImageServer creates a new webdav image server.
+func NewWebdavImageServer(opts ImageServerOptions, chroot bool) ImageServer {
+	return &webdavImageServer{
+		opts:   opts,
+		chroot: chroot,
+	}
+}
+
+// ServeImage Serves the image.
+func (s *webdavImageServer) ServeImage(imageMetadata *docker.Image) error {
+	servePath := s.opts.ImageServeURL
+	if s.chroot {
+		if err := syscall.Chroot(s.opts.ImageServeURL); err != nil {
+			return fmt.Errorf("Unable to chroot into %s: %v\n", s.opts.ImageServeURL, err)
+		}
+		servePath = CHROOT_SERVE_PATH
+	} else {
+		log.Printf("!!!WARNING!!! It is insecure to serve the image content without changing")
+		log.Printf("root (--chroot). Absolute-path symlinks in the image can lead to disclose")
+		log.Printf("information of the hosting system.")
+	}
+
+	log.Printf("Serving image content %s on webdav://%s%s", s.opts.ImageServeURL, s.opts.ServePath, s.opts.ContentURL)
+
+	http.HandleFunc(s.opts.HealthzURL, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok\n"))
+	})
+
+	http.HandleFunc(s.opts.APIURL, func(w http.ResponseWriter, r *http.Request) {
+		body, err := json.MarshalIndent(s.opts.APIVersions, "", "  ")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(body)
+	})
+
+	http.HandleFunc(s.opts.MetadataURL, func(w http.ResponseWriter, r *http.Request) {
+		body, err := json.MarshalIndent(imageMetadata, "", "  ")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(body)
+	})
+
+	http.Handle(s.opts.ContentURL, &webdav.Handler{
+		Prefix:     s.opts.ContentURL,
+		FileSystem: webdav.Dir(servePath),
+		LockSystem: webdav.NewMemLS(),
+	})
+
+	return http.ListenAndServe(s.opts.ServePath, nil)
+}


### PR DESCRIPTION
Abstract out the impl of serving images which will allow us to inject different types of server (useful for mocking in test if nothing else).

@simon3z  @enoodle 

I did notice the content url has `/` on it so you have to curl `http://0.0.0.0:8080/api/v1/content/` vs `http://0.0.0.0:8080/api/v1/content` to get the content.  If you curl just `http://0.0.0.0:8080/api/v1/content` you'll get `Permanently Moved`.  

Testing:

```
[pweil@localhost openshift-docs]$ curl 0.0.0.0:8080/healthz
ok
[pweil@localhost openshift-docs]$ curl 0.0.0.0:8080/api
{
  "versions": [
    "v1"
  ]
}
[pweil@localhost openshift-docs]$ curl 0.0.0.0:8080/api/v1/metadata
{
  "Id": "sha256:8b5cf972e254795d1eef4f66e1a71d3c6869bbf4773d9fb36fd8c13ead1a9d5d",
  "Created": "2016-02-18T16:47:39.452282864Z",
  "Container": "f8fb8c4a27ffec2f7fa19595696c7c42754cf6a80b309d56f014090a5f4bc54a",
  "ContainerConfig": {
    "Hostname": "f8fb8c4a27ff",
    "Cmd": [
      "/bin/sh",
      "-c",
      "#(nop) ADD file:b472211c9fa1cd451ea7e94eee2ef1cdaae0413110f560bce5cb183a795b47d7 in /"
    ],
    "Image": "b0082ba983ef3569aad347f923a9cec8ea764c239179081a1e2c47709788dc44",
    "Entrypoint": null
  },
  "DockerVersion": "1.9.1",
  "Author": "Adam Miller \u003cmaxamillion@fedoraproject.org\u003e",
  "Config": {
    "Hostname": "f8fb8c4a27ff",
    "Cmd": null,
    "Image": "b0082ba983ef3569aad347f923a9cec8ea764c239179081a1e2c47709788dc44",
    "Entrypoint": null
  },
  "Architecture": "amd64",
  "Size": 188718134,
  "VirtualSize": 188718134
}
[pweil@localhost openshift-docs]$ curl 0.0.0.0:8080/api/v1/content/
curl: (18) transfer closed with 9223372036854775807 bytes remaining to read
```
