### PR TITLE
[WIP] Inspector server authentication

### DIFF
--- a/cmd/image-inspector.go
+++ b/cmd/image-inspector.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 
 	iicmd "github.com/simon3z/image-inspector/pkg/cmd"
@@ -19,6 +20,7 @@ func main() {
 	flag.StringVar(&inspectorOptions.DockerCfg, "dockercfg", inspectorOptions.DockerCfg, "Location of the docker configuration file")
 	flag.StringVar(&inspectorOptions.Username, "username", inspectorOptions.Username, "username for authenticating with the docker registry")
 	flag.StringVar(&inspectorOptions.PasswordFile, "password-file", inspectorOptions.PasswordFile, "Location of a file that contains the password for authentication with the docker registry")
+	flag.StringVar(&inspectorOptions.ServerAuthType, "server-auth-type", inspectorOptions.ServerAuthType, fmt.Sprintf("The type of authentication to be used with the image server, possible values are %v", iicmd.ServerAuthOptions))
 
 	flag.Parse()
 

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -2,6 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	server "github.com/simon3z/image-inspector/pkg/imageserver"
+)
+
+var (
+	ServerAuthOptions = []string{
+		string(server.AllowAll),
+		string(server.KubernetesToken),
+	}
 )
 
 // ImageInspectorOptions is the main inspector implementation and holds the configuration
@@ -24,19 +32,22 @@ type ImageInspectorOptions struct {
 	// PasswordFile is the location of the file containing the password for authentication to the
 	// docker registry.
 	PasswordFile string
+	// ServerAuthType is the type of authentication used to access the server
+	ServerAuthType string
 }
 
 // NewDefaultImageInspectorOptions provides a new ImageInspectorOptions with default values.
 func NewDefaultImageInspectorOptions() *ImageInspectorOptions {
 	return &ImageInspectorOptions{
-		URI:          "unix:///var/run/docker.sock",
-		Image:        "",
-		DstPath:      "",
-		Serve:        "",
-		Chroot:       false,
-		DockerCfg:    "",
-		Username:     "",
-		PasswordFile: "",
+		URI:            "unix:///var/run/docker.sock",
+		Image:          "",
+		DstPath:        "",
+		Serve:          "",
+		Chroot:         false,
+		DockerCfg:      "",
+		Username:       "",
+		PasswordFile:   "",
+		ServerAuthType: "None",
 	}
 }
 
@@ -57,5 +68,17 @@ func (i *ImageInspectorOptions) Validate() error {
 	if len(i.Serve) == 0 && i.Chroot {
 		return fmt.Errorf("Change root can be used only when serving the image through webdav")
 	}
+	if !stringInSlice(i.ServerAuthType, ServerAuthOptions) {
+		return fmt.Errorf("server-auth-type can only be one of %v", ServerAuthOptions)
+	}
 	return nil
+}
+
+func stringInSlice(str string, list []string) bool {
+	for _, t := range list {
+		if t == str {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -1,0 +1,37 @@
+package imageserver
+
+import (
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+// ImageServer abstracts the serving of image information.
+type ImageServer interface {
+	// ServeImage Serves the image
+	ServeImage(imageMetadata *docker.Image) error
+}
+
+// APIVersions holds a slice of supported API versions.
+type APIVersions struct {
+	// Versions is the supported API versions
+	Versions []string `json:"versions"`
+}
+
+// ImageServerOptions is used to configure an image server.
+type ImageServerOptions struct {
+	// ServePath is the root path/port of serving. ex 0.0.0.0:8080
+	ServePath string
+	// HealthzURL is the relative url of the health check. ex /healthz
+	HealthzURL string
+	// APIURL is the relative url where the api will be served.  ex /api
+	APIURL string
+	// APIVersions are the supported API versions.
+	APIVersions APIVersions
+	// MetadataURL is the relative url of the metadata content.  ex /api/v1/metadata
+	MetadataURL string
+	// ContentURL is the relative url of the content.  ex /api/v1/content/
+	ContentURL string
+	// ImageServeURL is the location that the image is being served from.
+	// NOTE: if the image server supports a chroot the server implementation will perform
+	// the chroot based on this URL.
+	ImageServeURL string
+}

--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -4,6 +4,13 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
+type AuthenticationType string
+
+const (
+	AllowAll        AuthenticationType = "None"
+	KubernetesToken AuthenticationType = "KubenetesToken"
+)
+
 // ImageServer abstracts the serving of image information.
 type ImageServer interface {
 	// ServeImage Serves the image
@@ -34,4 +41,6 @@ type ImageServerOptions struct {
 	// NOTE: if the image server supports a chroot the server implementation will perform
 	// the chroot based on this URL.
 	ImageServeURL string
+	// AuthType is the type of authentication used to access the server
+	AuthType AuthenticationType
 }

--- a/pkg/imageserver/webdav.go
+++ b/pkg/imageserver/webdav.go
@@ -1,0 +1,83 @@
+package imageserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"syscall"
+
+	"golang.org/x/net/webdav"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+const (
+	// CHROOT_SERVE_PATH is the path to server if we are performing a chroot
+	// this probably does not belong here.
+	CHROOT_SERVE_PATH = "/"
+)
+
+// webdavImageServer implements ImageServer.
+type webdavImageServer struct {
+	opts   ImageServerOptions
+	chroot bool
+}
+
+// ensures this always implements the interface or fail compilation.
+var _ ImageServer = &webdavImageServer{}
+
+// NewWebdavImageServer creates a new webdav image server.
+func NewWebdavImageServer(opts ImageServerOptions, chroot bool) ImageServer {
+	return &webdavImageServer{
+		opts:   opts,
+		chroot: chroot,
+	}
+}
+
+// ServeImage Serves the image.
+func (s *webdavImageServer) ServeImage(imageMetadata *docker.Image) error {
+	servePath := s.opts.ImageServeURL
+	if s.chroot {
+		if err := syscall.Chroot(s.opts.ImageServeURL); err != nil {
+			return fmt.Errorf("Unable to chroot into %s: %v\n", s.opts.ImageServeURL, err)
+		}
+		servePath = CHROOT_SERVE_PATH
+	} else {
+		log.Printf("!!!WARNING!!! It is insecure to serve the image content without changing")
+		log.Printf("root (--chroot). Absolute-path symlinks in the image can lead to disclose")
+		log.Printf("information of the hosting system.")
+	}
+
+	log.Printf("Serving image content %s on webdav://%s%s", s.opts.ImageServeURL, s.opts.ServePath, s.opts.ContentURL)
+
+	http.HandleFunc(s.opts.HealthzURL, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok\n"))
+	})
+
+	http.HandleFunc(s.opts.APIURL, func(w http.ResponseWriter, r *http.Request) {
+		body, err := json.MarshalIndent(s.opts.APIVersions, "", "  ")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(body)
+	})
+
+	http.HandleFunc(s.opts.MetadataURL, func(w http.ResponseWriter, r *http.Request) {
+		body, err := json.MarshalIndent(imageMetadata, "", "  ")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(body)
+	})
+
+	http.Handle(s.opts.ContentURL, &webdav.Handler{
+		Prefix:     s.opts.ContentURL,
+		FileSystem: webdav.Dir(servePath),
+		LockSystem: webdav.NewMemLS(),
+	})
+
+	return http.ListenAndServe(s.opts.ServePath, nil)
+}

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -60,6 +60,7 @@ func NewDefaultImageInspector(opts iicmd.ImageInspectorOptions) ImageInspector {
 			MetadataURL:   METADATA_URL_PATH,
 			ContentURL:    CONTENT_URL_PREFIX,
 			ImageServeURL: opts.DstPath,
+			AuthType:      apiserver.AuthenticationType(opts.ServerAuthType),
 		}
 		inspector.imageServer = apiserver.NewWebdavImageServer(imageServerOpts, opts.Chroot)
 	}


### PR DESCRIPTION
Currently I implemented only one type of authentication with token through kubernetes. If we want this can be changed to a more configurable and with other sophisticated authentication methods. I added a new argument to the image inspector `--server-auth-type` and the current possible values are `None` (default) and `KubernetesToken`

based on #11 for convenience.
