### PR TITLE
fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Federico Simoncelli <fsimonce@redhat.com>
 
 RUN yum install -y golang openscap-scanner && yum clean all
 
-ENV PKGPATH=/go/src/github.com/openshift/image-inspector
+ENV PKGPATH=/go/src/github.com/simon3z/image-inspector
 
 WORKDIR $PKGPATH
 
@@ -11,7 +11,7 @@ ADD .   $PKGPATH
 ENV GOBIN  /usr/bin
 ENV GOPATH /go:$PKGPATH/Godeps/_workspace
 
-RUN go install github.com/openshift/image-inspector && \
+RUN go install $PKGPATH/cmd/image-inspector.go && \
     mkdir -p /var/lib/image-inspector
 
 EXPOSE 8080


### PR DESCRIPTION
Fixes https://github.com/simon3z/image-inspector/issues/15

I think I asked before but maybe I'm mistaken.  It doesn't look like we're merging this upstream to the OpenShift project right now.  If that is the long term plan then we need to rewrite the import paths since they all point to `simon3z`.  It requires 2 things:
1.  change the strings in our code
2.  setup our dev envs so that the gopath matches (just rename `simon3z` to `openshift`)

In any case, this fixes the build issue in the `simon3z` fork:

```
[pweil@localhost image-inspector]$ docker build -t pweil/image-inspector .
Sending build context to Docker daemon 1.614 MB
Step 1 : FROM openshift/origin-base
 ---> 54e5f249bce0
Step 2 : MAINTAINER Federico Simoncelli <fsimonce@redhat.com>
 ---> Using cache
 ---> 511b5ad109c1
Step 3 : RUN yum install -y golang openscap-scanner && yum clean all
 ---> Using cache
 ---> a082d949d4f4
Step 4 : ENV PKGPATH /go/src/github.com/simon3z/image-inspector
 ---> Using cache
 ---> 4f34c1467449
Step 5 : WORKDIR $PKGPATH
 ---> Using cache
 ---> 2520094613a0
Step 6 : ADD . $PKGPATH
 ---> c608dfe4ddc4
Removing intermediate container fb9e4aab51a7
Step 7 : ENV GOBIN /usr/bin
 ---> Running in 49e6941930cf
 ---> 592822dd0e58
Removing intermediate container 49e6941930cf
Step 8 : ENV GOPATH /go:$PKGPATH/Godeps/_workspace
 ---> Running in 3c1f91be3661
 ---> 2ad43704d7ee
Removing intermediate container 3c1f91be3661
Step 9 : RUN go install $PKGPATH/cmd/image-inspector.go &&     mkdir -p /var/lib/image-inspector
 ---> Running in 162dfcff76f1
 ---> be14a12f9e4b
Removing intermediate container 162dfcff76f1
Step 10 : EXPOSE 8080
 ---> Running in aeab75d289ce
 ---> f54ba1b960c0
Removing intermediate container aeab75d289ce
Step 11 : WORKDIR /var/lib/image-inspector
 ---> Running in 9846d544ab8e
 ---> 30c8f83296f1
Removing intermediate container 9846d544ab8e
Step 12 : ENTRYPOINT /usr/bin/image-inspector
 ---> Running in e9399d466621
 ---> 1bbd7b780e2b
Removing intermediate container e9399d466621
Successfully built 1bbd7b780e2b
[pweil@localhost image-inspector]$ docker run pweil/image-inspector
2016/04/26 21:04:59 package webdav requires Go version 1.5 or greater
2016/04/26 21:04:59 Docker image to inspect must be specified
```
